### PR TITLE
Adding the RF_Mordred baseline

### DIFF
--- a/analysis/moleculeace_results/RF_Mordred.md
+++ b/analysis/moleculeace_results/RF_Mordred.md
@@ -1,0 +1,1992 @@
+# Random Forest Baseline Results
+timestamp: 2025-06-05 11:50:27.890357
+## Random Seed 42
+
+### `CHEMBL1862_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.759907 |
+| noncliff test rmse | 0.735557 |
+| cliff test rmse    | 0.79281  |
+
+
+### `CHEMBL1871_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.698588 |
+| noncliff test rmse | 0.611825 |
+| cliff test rmse    | 0.922187 |
+
+
+### `CHEMBL2034_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.670914 |
+| noncliff test rmse | 0.596744 |
+| cliff test rmse    | 0.794315 |
+
+
+### `CHEMBL2047_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.658193 |
+| noncliff test rmse | 0.662634 |
+| cliff test rmse    | 0.651206 |
+
+
+### `CHEMBL204_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.824886 |
+| noncliff test rmse | 0.727167 |
+| cliff test rmse    | 0.953941 |
+
+
+### `CHEMBL2147_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.746536 |
+| noncliff test rmse | 0.779227 |
+| cliff test rmse    | 0.693383 |
+
+
+### `CHEMBL214_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.734678 |
+| noncliff test rmse | 0.666394 |
+| cliff test rmse    | 0.839137 |
+
+
+### `CHEMBL218_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.752179 |
+| noncliff test rmse | 0.72257  |
+| cliff test rmse    | 0.801008 |
+
+
+### `CHEMBL219_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.773504 |
+| noncliff test rmse | 0.75076  |
+| cliff test rmse    | 0.806999 |
+
+
+### `CHEMBL228_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.768458 |
+| noncliff test rmse | 0.738316 |
+| cliff test rmse    | 0.816954 |
+
+
+### `CHEMBL231_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.726967 |
+| noncliff test rmse | 0.736031 |
+| cliff test rmse    | 0.698083 |
+
+
+### `CHEMBL233_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.820398 |
+| noncliff test rmse | 0.774418 |
+| cliff test rmse    | 0.882095 |
+
+
+### `CHEMBL234_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.737324 |
+| noncliff test rmse | 0.762945 |
+| cliff test rmse    | 0.702877 |
+
+
+### `CHEMBL235_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.672284 |
+| noncliff test rmse | 0.577046 |
+| cliff test rmse    | 0.805289 |
+
+
+### `CHEMBL236_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.782398 |
+| noncliff test rmse | 0.751143 |
+| cliff test rmse    | 0.828629 |
+
+
+### `CHEMBL237_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.842451 |
+| noncliff test rmse | 0.823964 |
+| cliff test rmse    | 0.862702 |
+
+
+### `CHEMBL237_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.776328 |
+| noncliff test rmse | 0.72811  |
+| cliff test rmse    | 0.836629 |
+
+
+### `CHEMBL238_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.701779 |
+| noncliff test rmse | 0.705898 |
+| cliff test rmse    | 0.689812 |
+
+
+### `CHEMBL239_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.769686 |
+| noncliff test rmse | 0.664964 |
+| cliff test rmse    | 0.901063 |
+
+
+### `CHEMBL244_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.839566 |
+| noncliff test rmse | 0.835071 |
+| cliff test rmse    | 0.844475 |
+
+
+### `CHEMBL262_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.774024 |
+| noncliff test rmse | 0.766931 |
+| cliff test rmse    | 0.804533 |
+
+
+### `CHEMBL264_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.648629 |
+| noncliff test rmse | 0.61311  |
+| cliff test rmse    | 0.695368 |
+
+
+### `CHEMBL2835_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.410786 |
+| noncliff test rmse | 0.336673 |
+| cliff test rmse    | 0.806392 |
+
+
+### `CHEMBL287_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.701716 |
+| noncliff test rmse | 0.673139 |
+| cliff test rmse    | 0.744957 |
+
+
+### `CHEMBL2971_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.694117 |
+| noncliff test rmse | 0.666418 |
+| cliff test rmse    | 0.81392  |
+
+
+### `CHEMBL3979_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.683049 |
+| noncliff test rmse | 0.664715 |
+| cliff test rmse    | 0.707994 |
+
+
+### `CHEMBL4005_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.689512 |
+| noncliff test rmse | 0.581646 |
+| cliff test rmse    | 0.815486 |
+
+
+### `CHEMBL4203_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.944339 |
+| noncliff test rmse | 0.904764 |
+| cliff test rmse    | 1.28737  |
+
+
+### `CHEMBL4616_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.705219 |
+| noncliff test rmse | 0.696519 |
+| cliff test rmse    | 0.712994 |
+
+
+### `CHEMBL4792_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.749546 |
+| noncliff test rmse | 0.721453 |
+| cliff test rmse    | 0.772789 |
+
+
+### Summary
+
+```
+results_dict = {
+    "CHEMBL1862_Ki": {
+        "cliff": 0.7928098382079282,
+        "noncliff": 0.7355571849111214
+    },
+    "CHEMBL1871_Ki": {
+        "cliff": 0.9221865282259621,
+        "noncliff": 0.6118246831450106
+    },
+    "CHEMBL2034_Ki": {
+        "cliff": 0.7943153934110566,
+        "noncliff": 0.5967440385205871
+    },
+    "CHEMBL2047_EC50": {
+        "cliff": 0.6512055736391406,
+        "noncliff": 0.6626339627488749
+    },
+    "CHEMBL204_Ki": {
+        "cliff": 0.9539412696805774,
+        "noncliff": 0.7271667176463026
+    },
+    "CHEMBL2147_Ki": {
+        "cliff": 0.6933827483655864,
+        "noncliff": 0.7792267542204909
+    },
+    "CHEMBL214_Ki": {
+        "cliff": 0.8391367710867335,
+        "noncliff": 0.6663941397668116
+    },
+    "CHEMBL218_EC50": {
+        "cliff": 0.8010079578911418,
+        "noncliff": 0.7225699612223616
+    },
+    "CHEMBL219_Ki": {
+        "cliff": 0.806999093953496,
+        "noncliff": 0.750759903027693
+    },
+    "CHEMBL228_Ki": {
+        "cliff": 0.8169535688950312,
+        "noncliff": 0.7383160812843395
+    },
+    "CHEMBL231_Ki": {
+        "cliff": 0.6980826283648546,
+        "noncliff": 0.7360306628585193
+    },
+    "CHEMBL233_Ki": {
+        "cliff": 0.8820950964758887,
+        "noncliff": 0.7744176868656628
+    },
+    "CHEMBL234_Ki": {
+        "cliff": 0.7028768665880382,
+        "noncliff": 0.7629453058334428
+    },
+    "CHEMBL235_EC50": {
+        "cliff": 0.8052886743534066,
+        "noncliff": 0.5770458636576016
+    },
+    "CHEMBL236_Ki": {
+        "cliff": 0.8286287324420609,
+        "noncliff": 0.7511429485610658
+    },
+    "CHEMBL237_EC50": {
+        "cliff": 0.8627021170796176,
+        "noncliff": 0.823963637141724
+    },
+    "CHEMBL237_Ki": {
+        "cliff": 0.8366290397034117,
+        "noncliff": 0.7281097308984252
+    },
+    "CHEMBL238_Ki": {
+        "cliff": 0.6898117003561696,
+        "noncliff": 0.7058978521545085
+    },
+    "CHEMBL239_EC50": {
+        "cliff": 0.9010632982414577,
+        "noncliff": 0.6649637386361913
+    },
+    "CHEMBL244_Ki": {
+        "cliff": 0.8444745630609405,
+        "noncliff": 0.8350706266807213
+    },
+    "CHEMBL262_Ki": {
+        "cliff": 0.8045328592997232,
+        "noncliff": 0.7669311085232533
+    },
+    "CHEMBL264_Ki": {
+        "cliff": 0.6953682495734335,
+        "noncliff": 0.6131102032840986
+    },
+    "CHEMBL2835_Ki": {
+        "cliff": 0.8063924140313209,
+        "noncliff": 0.33667269659000626
+    },
+    "CHEMBL287_Ki": {
+        "cliff": 0.7449570390699867,
+        "noncliff": 0.6731394166229111
+    },
+    "CHEMBL2971_Ki": {
+        "cliff": 0.8139202178636016,
+        "noncliff": 0.6664175364379817
+    },
+    "CHEMBL3979_EC50": {
+        "cliff": 0.7079939958139634,
+        "noncliff": 0.664715109360644
+    },
+    "CHEMBL4005_Ki": {
+        "cliff": 0.8154857439052374,
+        "noncliff": 0.5816459241568017
+    },
+    "CHEMBL4203_Ki": {
+        "cliff": 1.2873713998716971,
+        "noncliff": 0.904764110870096
+    },
+    "CHEMBL4616_EC50": {
+        "cliff": 0.7129937844458983,
+        "noncliff": 0.6965192875775386
+    },
+    "CHEMBL4792_Ki": {
+        "cliff": 0.7727889544405435,
+        "noncliff": 0.7214531976283676
+    }
+}
+```
+## Random Seed 117
+
+### `CHEMBL1862_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.771088 |
+| noncliff test rmse | 0.739329 |
+| cliff test rmse    | 0.81356  |
+
+
+### `CHEMBL1871_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.689588 |
+| noncliff test rmse | 0.5985   |
+| cliff test rmse    | 0.921693 |
+
+
+### `CHEMBL2034_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.664533 |
+| noncliff test rmse | 0.598036 |
+| cliff test rmse    | 0.776571 |
+
+
+### `CHEMBL2047_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.666486 |
+| noncliff test rmse | 0.66682  |
+| cliff test rmse    | 0.665965 |
+
+
+### `CHEMBL204_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.837405 |
+| noncliff test rmse | 0.737531 |
+| cliff test rmse    | 0.969193 |
+
+
+### `CHEMBL2147_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.738512 |
+| noncliff test rmse | 0.771134 |
+| cliff test rmse    | 0.685441 |
+
+
+### `CHEMBL214_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.733924 |
+| noncliff test rmse | 0.664379 |
+| cliff test rmse    | 0.840087 |
+
+
+### `CHEMBL218_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.744938 |
+| noncliff test rmse | 0.714586 |
+| cliff test rmse    | 0.794905 |
+
+
+### `CHEMBL219_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.777944 |
+| noncliff test rmse | 0.752655 |
+| cliff test rmse    | 0.81505  |
+
+
+### `CHEMBL228_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.759865 |
+| noncliff test rmse | 0.731471 |
+| cliff test rmse    | 0.805656 |
+
+
+### `CHEMBL231_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.725551 |
+| noncliff test rmse | 0.730479 |
+| cliff test rmse    | 0.710033 |
+
+
+### `CHEMBL233_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.822139 |
+| noncliff test rmse | 0.773426 |
+| cliff test rmse    | 0.88727  |
+
+
+### `CHEMBL234_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.734375 |
+| noncliff test rmse | 0.759665 |
+| cliff test rmse    | 0.700387 |
+
+
+### `CHEMBL235_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.663117 |
+| noncliff test rmse | 0.561383 |
+| cliff test rmse    | 0.803419 |
+
+
+### `CHEMBL236_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.782188 |
+| noncliff test rmse | 0.748797 |
+| cliff test rmse    | 0.831419 |
+
+
+### `CHEMBL237_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.832441 |
+| noncliff test rmse | 0.795802 |
+| cliff test rmse    | 0.871681 |
+
+
+### `CHEMBL237_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.775473 |
+| noncliff test rmse | 0.730035 |
+| cliff test rmse    | 0.832515 |
+
+
+### `CHEMBL238_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.692456 |
+| noncliff test rmse | 0.691524 |
+| cliff test rmse    | 0.695128 |
+
+
+### `CHEMBL239_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.768103 |
+| noncliff test rmse | 0.665252 |
+| cliff test rmse    | 0.897421 |
+
+
+### `CHEMBL244_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.842563 |
+| noncliff test rmse | 0.840908 |
+| cliff test rmse    | 0.844377 |
+
+
+### `CHEMBL262_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.790418 |
+| noncliff test rmse | 0.775346 |
+| cliff test rmse    | 0.853664 |
+
+
+### `CHEMBL264_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.644947 |
+| noncliff test rmse | 0.602186 |
+| cliff test rmse    | 0.700503 |
+
+
+### `CHEMBL2835_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.41222  |
+| noncliff test rmse | 0.343475 |
+| cliff test rmse    | 0.788346 |
+
+
+### `CHEMBL287_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.709248 |
+| noncliff test rmse | 0.680508 |
+| cliff test rmse    | 0.752747 |
+
+
+### `CHEMBL2971_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.681879 |
+| noncliff test rmse | 0.652431 |
+| cliff test rmse    | 0.808288 |
+
+
+### `CHEMBL3979_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.673062 |
+| noncliff test rmse | 0.666055 |
+| cliff test rmse    | 0.682782 |
+
+
+### `CHEMBL4005_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.681242 |
+| noncliff test rmse | 0.572174 |
+| cliff test rmse    | 0.808157 |
+
+
+### `CHEMBL4203_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.947155 |
+| noncliff test rmse | 0.902569 |
+| cliff test rmse    | 1.32661  |
+
+
+### `CHEMBL4616_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.705222 |
+| noncliff test rmse | 0.691924 |
+| cliff test rmse    | 0.717033 |
+
+
+### `CHEMBL4792_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.750853 |
+| noncliff test rmse | 0.719078 |
+| cliff test rmse    | 0.777029 |
+
+
+### Summary
+
+```
+results_dict = {
+    "CHEMBL1862_Ki": {
+        "cliff": 0.8135595639007113,
+        "noncliff": 0.7393285216622514
+    },
+    "CHEMBL1871_Ki": {
+        "cliff": 0.9216929990225085,
+        "noncliff": 0.5985001225069203
+    },
+    "CHEMBL2034_Ki": {
+        "cliff": 0.7765705872393251,
+        "noncliff": 0.598035847520422
+    },
+    "CHEMBL2047_EC50": {
+        "cliff": 0.6659651040456389,
+        "noncliff": 0.6668199698881253
+    },
+    "CHEMBL204_Ki": {
+        "cliff": 0.9691929583683127,
+        "noncliff": 0.7375310953534718
+    },
+    "CHEMBL2147_Ki": {
+        "cliff": 0.6854413295162011,
+        "noncliff": 0.7711342186198498
+    },
+    "CHEMBL214_Ki": {
+        "cliff": 0.8400874633911397,
+        "noncliff": 0.6643790723934467
+    },
+    "CHEMBL218_EC50": {
+        "cliff": 0.7949049174376074,
+        "noncliff": 0.7145861873377956
+    },
+    "CHEMBL219_Ki": {
+        "cliff": 0.8150495596671986,
+        "noncliff": 0.7526547854340632
+    },
+    "CHEMBL228_Ki": {
+        "cliff": 0.8056562732697223,
+        "noncliff": 0.7314710779060133
+    },
+    "CHEMBL231_Ki": {
+        "cliff": 0.7100327513283544,
+        "noncliff": 0.7304793448411324
+    },
+    "CHEMBL233_Ki": {
+        "cliff": 0.8872703064103749,
+        "noncliff": 0.7734260519233864
+    },
+    "CHEMBL234_Ki": {
+        "cliff": 0.7003868309105706,
+        "noncliff": 0.7596647320476576
+    },
+    "CHEMBL235_EC50": {
+        "cliff": 0.8034189239869096,
+        "noncliff": 0.5613827700888786
+    },
+    "CHEMBL236_Ki": {
+        "cliff": 0.831419094571939,
+        "noncliff": 0.7487972381642427
+    },
+    "CHEMBL237_EC50": {
+        "cliff": 0.8716806391579965,
+        "noncliff": 0.7958019765123436
+    },
+    "CHEMBL237_Ki": {
+        "cliff": 0.8325145915726843,
+        "noncliff": 0.730035038214644
+    },
+    "CHEMBL238_Ki": {
+        "cliff": 0.6951280257379708,
+        "noncliff": 0.691523982405654
+    },
+    "CHEMBL239_EC50": {
+        "cliff": 0.8974206776678175,
+        "noncliff": 0.6652523386085286
+    },
+    "CHEMBL244_Ki": {
+        "cliff": 0.8443772335654112,
+        "noncliff": 0.8409078681679971
+    },
+    "CHEMBL262_Ki": {
+        "cliff": 0.8536644253304504,
+        "noncliff": 0.7753456918100219
+    },
+    "CHEMBL264_Ki": {
+        "cliff": 0.7005031811875928,
+        "noncliff": 0.6021861980262223
+    },
+    "CHEMBL2835_Ki": {
+        "cliff": 0.7883461368762279,
+        "noncliff": 0.3434750471774647
+    },
+    "CHEMBL287_Ki": {
+        "cliff": 0.7527470131131334,
+        "noncliff": 0.680507603914537
+    },
+    "CHEMBL2971_Ki": {
+        "cliff": 0.8082881263880025,
+        "noncliff": 0.65243104875685
+    },
+    "CHEMBL3979_EC50": {
+        "cliff": 0.6827815899835484,
+        "noncliff": 0.6660547352284046
+    },
+    "CHEMBL4005_Ki": {
+        "cliff": 0.8081568523388334,
+        "noncliff": 0.5721738436921464
+    },
+    "CHEMBL4203_Ki": {
+        "cliff": 1.326608823522921,
+        "noncliff": 0.9025689350611886
+    },
+    "CHEMBL4616_EC50": {
+        "cliff": 0.7170326944836218,
+        "noncliff": 0.6919240668877811
+    },
+    "CHEMBL4792_Ki": {
+        "cliff": 0.7770291542771971,
+        "noncliff": 0.719078078719537
+    }
+}
+```
+## Random Seed 709
+
+### `CHEMBL1862_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.764841 |
+| noncliff test rmse | 0.730591 |
+| cliff test rmse    | 0.810456 |
+
+
+### `CHEMBL1871_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.70221  |
+| noncliff test rmse | 0.613262 |
+| cliff test rmse    | 0.930624 |
+
+
+### `CHEMBL2034_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.667219 |
+| noncliff test rmse | 0.584032 |
+| cliff test rmse    | 0.803337 |
+
+
+### `CHEMBL2047_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.666139 |
+| noncliff test rmse | 0.671927 |
+| cliff test rmse    | 0.657007 |
+
+
+### `CHEMBL204_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.834153 |
+| noncliff test rmse | 0.738044 |
+| cliff test rmse    | 0.961521 |
+
+
+### `CHEMBL2147_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.731226 |
+| noncliff test rmse | 0.754401 |
+| cliff test rmse    | 0.69416  |
+
+
+### `CHEMBL214_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.736287 |
+| noncliff test rmse | 0.663203 |
+| cliff test rmse    | 0.847275 |
+
+
+### `CHEMBL218_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.748322 |
+| noncliff test rmse | 0.721655 |
+| cliff test rmse    | 0.79251  |
+
+
+### `CHEMBL219_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.780275 |
+| noncliff test rmse | 0.754588 |
+| cliff test rmse    | 0.817945 |
+
+
+### `CHEMBL228_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.763492 |
+| noncliff test rmse | 0.731241 |
+| cliff test rmse    | 0.815188 |
+
+
+### `CHEMBL231_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.730538 |
+| noncliff test rmse | 0.74067  |
+| cliff test rmse    | 0.698148 |
+
+
+### `CHEMBL233_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.825281 |
+| noncliff test rmse | 0.782023 |
+| cliff test rmse    | 0.883563 |
+
+
+### `CHEMBL234_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.746435 |
+| noncliff test rmse | 0.773067 |
+| cliff test rmse    | 0.71059  |
+
+
+### `CHEMBL235_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.66571  |
+| noncliff test rmse | 0.555437 |
+| cliff test rmse    | 0.815834 |
+
+
+### `CHEMBL236_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.791896 |
+| noncliff test rmse | 0.759995 |
+| cliff test rmse    | 0.839065 |
+
+
+### `CHEMBL237_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.83476  |
+| noncliff test rmse | 0.791849 |
+| cliff test rmse    | 0.880376 |
+
+
+### `CHEMBL237_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.785857 |
+| noncliff test rmse | 0.732851 |
+| cliff test rmse    | 0.851767 |
+
+
+### `CHEMBL238_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.699021 |
+| noncliff test rmse | 0.693816 |
+| cliff test rmse    | 0.713765 |
+
+
+### `CHEMBL239_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.778651 |
+| noncliff test rmse | 0.665192 |
+| cliff test rmse    | 0.919584 |
+
+
+### `CHEMBL244_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.851485 |
+| noncliff test rmse | 0.838498 |
+| cliff test rmse    | 0.865521 |
+
+
+### `CHEMBL262_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.795967 |
+| noncliff test rmse | 0.785976 |
+| cliff test rmse    | 0.838573 |
+
+
+### `CHEMBL264_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.644954 |
+| noncliff test rmse | 0.610853 |
+| cliff test rmse    | 0.689921 |
+
+
+### `CHEMBL2835_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.409968 |
+| noncliff test rmse | 0.328068 |
+| cliff test rmse    | 0.832752 |
+
+
+### `CHEMBL287_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.707888 |
+| noncliff test rmse | 0.678832 |
+| cliff test rmse    | 0.751838 |
+
+
+### `CHEMBL2971_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.679852 |
+| noncliff test rmse | 0.649951 |
+| cliff test rmse    | 0.807974 |
+
+
+### `CHEMBL3979_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.681613 |
+| noncliff test rmse | 0.671486 |
+| cliff test rmse    | 0.695586 |
+
+
+### `CHEMBL4005_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.689466 |
+| noncliff test rmse | 0.580348 |
+| cliff test rmse    | 0.81667  |
+
+
+### `CHEMBL4203_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.939053 |
+| noncliff test rmse | 0.896293 |
+| cliff test rmse    | 1.30492  |
+
+
+### `CHEMBL4616_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.708685 |
+| noncliff test rmse | 0.692581 |
+| cliff test rmse    | 0.722936 |
+
+
+### `CHEMBL4792_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.737746 |
+| noncliff test rmse | 0.705765 |
+| cliff test rmse    | 0.764067 |
+
+
+### Summary
+
+```
+results_dict = {
+    "CHEMBL1862_Ki": {
+        "cliff": 0.8104564073642656,
+        "noncliff": 0.7305907475519269
+    },
+    "CHEMBL1871_Ki": {
+        "cliff": 0.9306240882184817,
+        "noncliff": 0.6132619685325806
+    },
+    "CHEMBL2034_Ki": {
+        "cliff": 0.8033371737857223,
+        "noncliff": 0.5840324375007766
+    },
+    "CHEMBL2047_EC50": {
+        "cliff": 0.6570074789266397,
+        "noncliff": 0.671926942295841
+    },
+    "CHEMBL204_Ki": {
+        "cliff": 0.9615212012055074,
+        "noncliff": 0.7380443748583833
+    },
+    "CHEMBL2147_Ki": {
+        "cliff": 0.6941597184045044,
+        "noncliff": 0.7544013988887299
+    },
+    "CHEMBL214_Ki": {
+        "cliff": 0.8472751375741123,
+        "noncliff": 0.6632025340751161
+    },
+    "CHEMBL218_EC50": {
+        "cliff": 0.7925096249819433,
+        "noncliff": 0.721654694459125
+    },
+    "CHEMBL219_Ki": {
+        "cliff": 0.8179449811968039,
+        "noncliff": 0.7545876312597539
+    },
+    "CHEMBL228_Ki": {
+        "cliff": 0.8151877748125645,
+        "noncliff": 0.7312411015136885
+    },
+    "CHEMBL231_Ki": {
+        "cliff": 0.6981479960926413,
+        "noncliff": 0.7406704278402954
+    },
+    "CHEMBL233_Ki": {
+        "cliff": 0.8835633200470231,
+        "noncliff": 0.7820225664146103
+    },
+    "CHEMBL234_Ki": {
+        "cliff": 0.7105896566525416,
+        "noncliff": 0.7730671906698262
+    },
+    "CHEMBL235_EC50": {
+        "cliff": 0.8158335211627119,
+        "noncliff": 0.5554371682610704
+    },
+    "CHEMBL236_Ki": {
+        "cliff": 0.8390653067578943,
+        "noncliff": 0.7599951879951066
+    },
+    "CHEMBL237_EC50": {
+        "cliff": 0.880376249077172,
+        "noncliff": 0.79184864261686
+    },
+    "CHEMBL237_Ki": {
+        "cliff": 0.8517674132052252,
+        "noncliff": 0.7328509924308715
+    },
+    "CHEMBL238_Ki": {
+        "cliff": 0.7137645273969084,
+        "noncliff": 0.6938155225472928
+    },
+    "CHEMBL239_EC50": {
+        "cliff": 0.919583533949335,
+        "noncliff": 0.6651923529257583
+    },
+    "CHEMBL244_Ki": {
+        "cliff": 0.8655211887462243,
+        "noncliff": 0.8384977863944127
+    },
+    "CHEMBL262_Ki": {
+        "cliff": 0.8385727654084598,
+        "noncliff": 0.7859760294119227
+    },
+    "CHEMBL264_Ki": {
+        "cliff": 0.6899212881670944,
+        "noncliff": 0.610852712510244
+    },
+    "CHEMBL2835_Ki": {
+        "cliff": 0.8327519783399278,
+        "noncliff": 0.3280683162123558
+    },
+    "CHEMBL287_Ki": {
+        "cliff": 0.751837900346475,
+        "noncliff": 0.6788317771623249
+    },
+    "CHEMBL2971_Ki": {
+        "cliff": 0.8079739910955711,
+        "noncliff": 0.6499510240500328
+    },
+    "CHEMBL3979_EC50": {
+        "cliff": 0.6955858086318335,
+        "noncliff": 0.6714857441822831
+    },
+    "CHEMBL4005_Ki": {
+        "cliff": 0.816670182019283,
+        "noncliff": 0.5803480561640578
+    },
+    "CHEMBL4203_Ki": {
+        "cliff": 1.304922619727107,
+        "noncliff": 0.8962932819268623
+    },
+    "CHEMBL4616_EC50": {
+        "cliff": 0.7229358152823905,
+        "noncliff": 0.6925808886413811
+    },
+    "CHEMBL4792_Ki": {
+        "cliff": 0.7640669288743305,
+        "noncliff": 0.7057653219071769
+    }
+}
+```
+## Random Seed 1701
+
+### `CHEMBL1862_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.769529 |
+| noncliff test rmse | 0.747946 |
+| cliff test rmse    | 0.798827 |
+
+
+### `CHEMBL1871_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.701816 |
+| noncliff test rmse | 0.611273 |
+| cliff test rmse    | 0.933548 |
+
+
+### `CHEMBL2034_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.664188 |
+| noncliff test rmse | 0.586091 |
+| cliff test rmse    | 0.793045 |
+
+
+### `CHEMBL2047_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.660559 |
+| noncliff test rmse | 0.653299 |
+| cliff test rmse    | 0.671727 |
+
+
+### `CHEMBL204_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.842705 |
+| noncliff test rmse | 0.739382 |
+| cliff test rmse    | 0.97856  |
+
+
+### `CHEMBL2147_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.737112 |
+| noncliff test rmse | 0.771531 |
+| cliff test rmse    | 0.680923 |
+
+
+### `CHEMBL214_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.738401 |
+| noncliff test rmse | 0.671122 |
+| cliff test rmse    | 0.841542 |
+
+
+### `CHEMBL218_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.758119 |
+| noncliff test rmse | 0.722301 |
+| cliff test rmse    | 0.816603 |
+
+
+### `CHEMBL219_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.771653 |
+| noncliff test rmse | 0.74803  |
+| cliff test rmse    | 0.806392 |
+
+
+### `CHEMBL228_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.763951 |
+| noncliff test rmse | 0.727759 |
+| cliff test rmse    | 0.821596 |
+
+
+### `CHEMBL231_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.716226 |
+| noncliff test rmse | 0.718932 |
+| cliff test rmse    | 0.70776  |
+
+
+### `CHEMBL233_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.815891 |
+| noncliff test rmse | 0.759886 |
+| cliff test rmse    | 0.889996 |
+
+
+### `CHEMBL234_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.732565 |
+| noncliff test rmse | 0.75693  |
+| cliff test rmse    | 0.699866 |
+
+
+### `CHEMBL235_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.659964 |
+| noncliff test rmse | 0.563753 |
+| cliff test rmse    | 0.793733 |
+
+
+### `CHEMBL236_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.787727 |
+| noncliff test rmse | 0.74844  |
+| cliff test rmse    | 0.845161 |
+
+
+### `CHEMBL237_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.843625 |
+| noncliff test rmse | 0.817465 |
+| cliff test rmse    | 0.872014 |
+
+
+### `CHEMBL237_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.779732 |
+| noncliff test rmse | 0.725124 |
+| cliff test rmse    | 0.847446 |
+
+
+### `CHEMBL238_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.700134 |
+| noncliff test rmse | 0.69643  |
+| cliff test rmse    | 0.710667 |
+
+
+### `CHEMBL239_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.772569 |
+| noncliff test rmse | 0.661165 |
+| cliff test rmse    | 0.911162 |
+
+
+### `CHEMBL244_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.846373 |
+| noncliff test rmse | 0.835881 |
+| cliff test rmse    | 0.857745 |
+
+
+### `CHEMBL262_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.781611 |
+| noncliff test rmse | 0.772009 |
+| cliff test rmse    | 0.822585 |
+
+
+### `CHEMBL264_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.645162 |
+| noncliff test rmse | 0.611967 |
+| cliff test rmse    | 0.689005 |
+
+
+### `CHEMBL2835_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.404479 |
+| noncliff test rmse | 0.335749 |
+| cliff test rmse    | 0.778352 |
+
+
+### `CHEMBL287_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.702661 |
+| noncliff test rmse | 0.667985 |
+| cliff test rmse    | 0.754592 |
+
+
+### `CHEMBL2971_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.670045 |
+| noncliff test rmse | 0.643689 |
+| cliff test rmse    | 0.784192 |
+
+
+### `CHEMBL3979_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.666629 |
+| noncliff test rmse | 0.660079 |
+| cliff test rmse    | 0.67572  |
+
+
+### `CHEMBL4005_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.687124 |
+| noncliff test rmse | 0.582321 |
+| cliff test rmse    | 0.81     |
+
+
+### `CHEMBL4203_Ki`
+
+| metric             |   value |
+|:-------------------|--------:|
+| overall test rmse  | 0.95283 |
+| noncliff test rmse | 0.91346 |
+| cliff test rmse    | 1.29482 |
+
+
+### `CHEMBL4616_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.716452 |
+| noncliff test rmse | 0.711562 |
+| cliff test rmse    | 0.720846 |
+
+
+### `CHEMBL4792_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.750238 |
+| noncliff test rmse | 0.729837 |
+| cliff test rmse    | 0.767275 |
+
+
+### Summary
+
+```
+results_dict = {
+    "CHEMBL1862_Ki": {
+        "cliff": 0.7988273846647209,
+        "noncliff": 0.7479461271581402
+    },
+    "CHEMBL1871_Ki": {
+        "cliff": 0.933547548938125,
+        "noncliff": 0.6112726222989835
+    },
+    "CHEMBL2034_Ki": {
+        "cliff": 0.7930447559412533,
+        "noncliff": 0.5860907222038274
+    },
+    "CHEMBL2047_EC50": {
+        "cliff": 0.6717274131085887,
+        "noncliff": 0.6532990369449898
+    },
+    "CHEMBL204_Ki": {
+        "cliff": 0.9785595320601875,
+        "noncliff": 0.7393823631966259
+    },
+    "CHEMBL2147_Ki": {
+        "cliff": 0.680922640511638,
+        "noncliff": 0.7715309116946497
+    },
+    "CHEMBL214_Ki": {
+        "cliff": 0.841541598078459,
+        "noncliff": 0.6711219839068856
+    },
+    "CHEMBL218_EC50": {
+        "cliff": 0.8166031203388616,
+        "noncliff": 0.7223009272589282
+    },
+    "CHEMBL219_Ki": {
+        "cliff": 0.8063918800405757,
+        "noncliff": 0.7480301951547131
+    },
+    "CHEMBL228_Ki": {
+        "cliff": 0.821595879269848,
+        "noncliff": 0.7277591356321954
+    },
+    "CHEMBL231_Ki": {
+        "cliff": 0.7077602023855926,
+        "noncliff": 0.7189315153087789
+    },
+    "CHEMBL233_Ki": {
+        "cliff": 0.8899959168136973,
+        "noncliff": 0.759886001789657
+    },
+    "CHEMBL234_Ki": {
+        "cliff": 0.69986554496662,
+        "noncliff": 0.7569302219728995
+    },
+    "CHEMBL235_EC50": {
+        "cliff": 0.7937329414719005,
+        "noncliff": 0.5637533914600364
+    },
+    "CHEMBL236_Ki": {
+        "cliff": 0.8451606336891727,
+        "noncliff": 0.7484401105603248
+    },
+    "CHEMBL237_EC50": {
+        "cliff": 0.8720143542008308,
+        "noncliff": 0.8174645406404549
+    },
+    "CHEMBL237_Ki": {
+        "cliff": 0.8474462102539094,
+        "noncliff": 0.7251241935935494
+    },
+    "CHEMBL238_Ki": {
+        "cliff": 0.7106671027127931,
+        "noncliff": 0.696429893044697
+    },
+    "CHEMBL239_EC50": {
+        "cliff": 0.9111623889246704,
+        "noncliff": 0.6611653738365042
+    },
+    "CHEMBL244_Ki": {
+        "cliff": 0.8577453189738428,
+        "noncliff": 0.835880592676928
+    },
+    "CHEMBL262_Ki": {
+        "cliff": 0.8225851892220409,
+        "noncliff": 0.7720092975249058
+    },
+    "CHEMBL264_Ki": {
+        "cliff": 0.6890050612012928,
+        "noncliff": 0.6119667440321003
+    },
+    "CHEMBL2835_Ki": {
+        "cliff": 0.7783519568470488,
+        "noncliff": 0.33574938800680654
+    },
+    "CHEMBL287_Ki": {
+        "cliff": 0.7545921683280419,
+        "noncliff": 0.6679854298342303
+    },
+    "CHEMBL2971_Ki": {
+        "cliff": 0.7841920086766434,
+        "noncliff": 0.6436886544704405
+    },
+    "CHEMBL3979_EC50": {
+        "cliff": 0.6757201118638828,
+        "noncliff": 0.660079422284348
+    },
+    "CHEMBL4005_Ki": {
+        "cliff": 0.8099999633512823,
+        "noncliff": 0.582320882495226
+    },
+    "CHEMBL4203_Ki": {
+        "cliff": 1.2948180783172165,
+        "noncliff": 0.9134604758073661
+    },
+    "CHEMBL4616_EC50": {
+        "cliff": 0.7208455440777334,
+        "noncliff": 0.7115615040261429
+    },
+    "CHEMBL4792_Ki": {
+        "cliff": 0.767274655148874,
+        "noncliff": 0.7298371436711745
+    }
+}
+```
+## Random Seed 9001
+
+### `CHEMBL1862_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.777918 |
+| noncliff test rmse | 0.755175 |
+| cliff test rmse    | 0.808748 |
+
+
+### `CHEMBL1871_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.703364 |
+| noncliff test rmse | 0.623104 |
+| cliff test rmse    | 0.913276 |
+
+
+### `CHEMBL2034_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.682547 |
+| noncliff test rmse | 0.604343 |
+| cliff test rmse    | 0.812041 |
+
+
+### `CHEMBL2047_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.643966 |
+| noncliff test rmse | 0.646946 |
+| cliff test rmse    | 0.639289 |
+
+
+### `CHEMBL204_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.8349   |
+| noncliff test rmse | 0.725443 |
+| cliff test rmse    | 0.977533 |
+
+
+### `CHEMBL2147_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.731673 |
+| noncliff test rmse | 0.766648 |
+| cliff test rmse    | 0.674488 |
+
+
+### `CHEMBL214_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.735885 |
+| noncliff test rmse | 0.665253 |
+| cliff test rmse    | 0.843555 |
+
+
+### `CHEMBL218_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.748014 |
+| noncliff test rmse | 0.713586 |
+| cliff test rmse    | 0.804315 |
+
+
+### `CHEMBL219_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.782299 |
+| noncliff test rmse | 0.758173 |
+| cliff test rmse    | 0.817767 |
+
+
+### `CHEMBL228_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.758312 |
+| noncliff test rmse | 0.737641 |
+| cliff test rmse    | 0.792077 |
+
+
+### `CHEMBL231_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.73122  |
+| noncliff test rmse | 0.733759 |
+| cliff test rmse    | 0.723279 |
+
+
+### `CHEMBL233_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.821893 |
+| noncliff test rmse | 0.776943 |
+| cliff test rmse    | 0.882301 |
+
+
+### `CHEMBL234_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.733107 |
+| noncliff test rmse | 0.759778 |
+| cliff test rmse    | 0.697177 |
+
+
+### `CHEMBL235_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.659256 |
+| noncliff test rmse | 0.560278 |
+| cliff test rmse    | 0.796234 |
+
+
+### `CHEMBL236_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.794764 |
+| noncliff test rmse | 0.762521 |
+| cliff test rmse    | 0.842421 |
+
+
+### `CHEMBL237_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.840619 |
+| noncliff test rmse | 0.819107 |
+| cliff test rmse    | 0.864095 |
+
+
+### `CHEMBL237_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.785191 |
+| noncliff test rmse | 0.74199  |
+| cliff test rmse    | 0.839634 |
+
+
+### `CHEMBL238_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.686643 |
+| noncliff test rmse | 0.68402  |
+| cliff test rmse    | 0.694123 |
+
+
+### `CHEMBL239_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.768026 |
+| noncliff test rmse | 0.659977 |
+| cliff test rmse    | 0.902933 |
+
+
+### `CHEMBL244_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.840065 |
+| noncliff test rmse | 0.82804  |
+| cliff test rmse    | 0.853072 |
+
+
+### `CHEMBL262_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.796564 |
+| noncliff test rmse | 0.786537 |
+| cliff test rmse    | 0.839322 |
+
+
+### `CHEMBL264_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.649211 |
+| noncliff test rmse | 0.613476 |
+| cliff test rmse    | 0.696218 |
+
+
+### `CHEMBL2835_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.412083 |
+| noncliff test rmse | 0.340612 |
+| cliff test rmse    | 0.798389 |
+
+
+### `CHEMBL287_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.688257 |
+| noncliff test rmse | 0.659381 |
+| cliff test rmse    | 0.731888 |
+
+
+### `CHEMBL2971_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.698294 |
+| noncliff test rmse | 0.671492 |
+| cliff test rmse    | 0.814631 |
+
+
+### `CHEMBL3979_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.682268 |
+| noncliff test rmse | 0.676695 |
+| cliff test rmse    | 0.690018 |
+
+
+### `CHEMBL4005_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.677455 |
+| noncliff test rmse | 0.574863 |
+| cliff test rmse    | 0.797868 |
+
+
+### `CHEMBL4203_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.949571 |
+| noncliff test rmse | 0.909794 |
+| cliff test rmse    | 1.29438  |
+
+
+### `CHEMBL4616_EC50`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.716083 |
+| noncliff test rmse | 0.704652 |
+| cliff test rmse    | 0.726263 |
+
+
+### `CHEMBL4792_Ki`
+
+| metric             |    value |
+|:-------------------|---------:|
+| overall test rmse  | 0.744319 |
+| noncliff test rmse | 0.717703 |
+| cliff test rmse    | 0.766375 |
+
+
+### Summary
+
+```
+results_dict = {
+    "CHEMBL1862_Ki": {
+        "cliff": 0.8087483849320498,
+        "noncliff": 0.7551752509135817
+    },
+    "CHEMBL1871_Ki": {
+        "cliff": 0.9132762882256767,
+        "noncliff": 0.6231035687049781
+    },
+    "CHEMBL2034_Ki": {
+        "cliff": 0.8120409363550019,
+        "noncliff": 0.6043430313020067
+    },
+    "CHEMBL2047_EC50": {
+        "cliff": 0.6392889639087556,
+        "noncliff": 0.6469457756464354
+    },
+    "CHEMBL204_Ki": {
+        "cliff": 0.9775327611523154,
+        "noncliff": 0.7254434081399874
+    },
+    "CHEMBL2147_Ki": {
+        "cliff": 0.6744883628882417,
+        "noncliff": 0.7666478987983922
+    },
+    "CHEMBL214_Ki": {
+        "cliff": 0.8435552519797332,
+        "noncliff": 0.6652526749774541
+    },
+    "CHEMBL218_EC50": {
+        "cliff": 0.8043146904278671,
+        "noncliff": 0.7135858371992767
+    },
+    "CHEMBL219_Ki": {
+        "cliff": 0.8177673072340655,
+        "noncliff": 0.7581734026527697
+    },
+    "CHEMBL228_Ki": {
+        "cliff": 0.7920772264674953,
+        "noncliff": 0.7376412771021665
+    },
+    "CHEMBL231_Ki": {
+        "cliff": 0.7232791707317534,
+        "noncliff": 0.7337592950161411
+    },
+    "CHEMBL233_Ki": {
+        "cliff": 0.8823011479962164,
+        "noncliff": 0.7769425516979269
+    },
+    "CHEMBL234_Ki": {
+        "cliff": 0.6971773762570159,
+        "noncliff": 0.759777737373454
+    },
+    "CHEMBL235_EC50": {
+        "cliff": 0.7962343214848304,
+        "noncliff": 0.5602782718147544
+    },
+    "CHEMBL236_Ki": {
+        "cliff": 0.8424214506606182,
+        "noncliff": 0.7625209161568637
+    },
+    "CHEMBL237_EC50": {
+        "cliff": 0.8640954213854881,
+        "noncliff": 0.8191067214965166
+    },
+    "CHEMBL237_Ki": {
+        "cliff": 0.8396344036196816,
+        "noncliff": 0.7419899262138443
+    },
+    "CHEMBL238_Ki": {
+        "cliff": 0.6941232667753683,
+        "noncliff": 0.6840203972171447
+    },
+    "CHEMBL239_EC50": {
+        "cliff": 0.9029330419131775,
+        "noncliff": 0.6599771854206742
+    },
+    "CHEMBL244_Ki": {
+        "cliff": 0.8530716210288875,
+        "noncliff": 0.8280402933109987
+    },
+    "CHEMBL262_Ki": {
+        "cliff": 0.8393224433906141,
+        "noncliff": 0.7865369905027981
+    },
+    "CHEMBL264_Ki": {
+        "cliff": 0.696218216379977,
+        "noncliff": 0.6134761369465241
+    },
+    "CHEMBL2835_Ki": {
+        "cliff": 0.7983891087286727,
+        "noncliff": 0.3406121583046034
+    },
+    "CHEMBL287_Ki": {
+        "cliff": 0.7318878177266488,
+        "noncliff": 0.6593811855068972
+    },
+    "CHEMBL2971_Ki": {
+        "cliff": 0.8146310641084774,
+        "noncliff": 0.6714917050833902
+    },
+    "CHEMBL3979_EC50": {
+        "cliff": 0.6900180910476352,
+        "noncliff": 0.6766950092770792
+    },
+    "CHEMBL4005_Ki": {
+        "cliff": 0.7978677155267985,
+        "noncliff": 0.5748634598132883
+    },
+    "CHEMBL4203_Ki": {
+        "cliff": 1.294377433149094,
+        "noncliff": 0.9097944594101318
+    },
+    "CHEMBL4616_EC50": {
+        "cliff": 0.7262632598768367,
+        "noncliff": 0.7046518450174389
+    },
+    "CHEMBL4792_Ki": {
+        "cliff": 0.7663746687553725,
+        "noncliff": 0.7177030016986378
+    }
+}
+```

--- a/analysis/polaris_results/RF_Mordred.md
+++ b/analysis/polaris_results/RF_Mordred.md
@@ -1,0 +1,1437 @@
+# Random Forest Baseline Results
+timestamp: 2025-06-05 09:08:36.624268
+## Random Seed 42
+
+### `polaris/pkis2-ret-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_RET        | f1          | 0.272727 |
+|  1 | test       | CLS_RET        | pr_auc      | 0.424536 |
+|  2 | test       | CLS_RET        | cohen_kappa | 0.215541 |
+|  3 | test       | CLS_RET        | mcc         | 0.266557 |
+|  4 | test       | CLS_RET        | roc_auc     | 0.728685 |
+|  5 | test       | CLS_RET        | accuracy    | 0.849057 |
+
+
+### `polaris/pkis2-ret-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | RET            | mean_squared_error  | 948.733    |
+|  1 | test       | RET            | explained_var       |   0.228378 |
+|  2 | test       | RET            | mean_absolute_error |  23.5413   |
+|  3 | test       | RET            | r2                  |   0.201003 |
+|  4 | test       | RET            | pearsonr            |   0.477959 |
+|  5 | test       | RET            | spearmanr           |   0.457443 |
+
+
+### `polaris/pkis2-kit-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_KIT        | f1          | 0.432432 |
+|  1 | test       | CLS_KIT        | pr_auc      | 0.528372 |
+|  2 | test       | CLS_KIT        | cohen_kappa | 0.329295 |
+|  3 | test       | CLS_KIT        | mcc         | 0.337847 |
+|  4 | test       | CLS_KIT        | roc_auc     | 0.790135 |
+|  5 | test       | CLS_KIT        | accuracy    | 0.818966 |
+
+
+### `polaris/pkis2-kit-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | KIT            | mean_squared_error  | 867.584    |
+|  1 | test       | KIT            | explained_var       |   0.286036 |
+|  2 | test       | KIT            | mean_absolute_error |  23.5457   |
+|  3 | test       | KIT            | r2                  |   0.281018 |
+|  4 | test       | KIT            | pearsonr            |   0.536991 |
+|  5 | test       | KIT            | spearmanr           |   0.487856 |
+
+
+### `polaris/pkis2-egfr-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | EGFR           | mean_squared_error  | 514.957    |
+|  1 | test       | EGFR           | explained_var       |   0.362066 |
+|  2 | test       | EGFR           | mean_absolute_error |  17.6102   |
+|  3 | test       | EGFR           | r2                  |   0.360912 |
+|  4 | test       | EGFR           | pearsonr            |   0.605712 |
+|  5 | test       | EGFR           | spearmanr           |   0.358143 |
+
+
+### `polaris/adme-fang-solu-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_SOLUBILITY | mean_squared_error  | 0.38763  |
+|  1 | test       | LOG_SOLUBILITY | explained_var       | 0.285608 |
+|  2 | test       | LOG_SOLUBILITY | mean_absolute_error | 0.435306 |
+|  3 | test       | LOG_SOLUBILITY | r2                  | 0.285051 |
+|  4 | test       | LOG_SOLUBILITY | pearsonr            | 0.53621  |
+|  5 | test       | LOG_SOLUBILITY | spearmanr           | 0.455171 |
+
+
+### `polaris/adme-fang-rppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RPPB       | mean_squared_error  | 0.499332 |
+|  1 | test       | LOG_RPPB       | explained_var       | 0.438003 |
+|  2 | test       | LOG_RPPB       | mean_absolute_error | 0.508196 |
+|  3 | test       | LOG_RPPB       | r2                  | 0.437994 |
+|  4 | test       | LOG_RPPB       | pearsonr            | 0.696383 |
+|  5 | test       | LOG_RPPB       | spearmanr           | 0.832174 |
+
+
+### `polaris/adme-fang-hppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HPPB       | mean_squared_error  | 0.237494 |
+|  1 | test       | LOG_HPPB       | explained_var       | 0.65428  |
+|  2 | test       | LOG_HPPB       | mean_absolute_error | 0.392077 |
+|  3 | test       | LOG_HPPB       | r2                  | 0.607861 |
+|  4 | test       | LOG_HPPB       | pearsonr            | 0.810455 |
+|  5 | test       | LOG_HPPB       | spearmanr           | 0.814119 |
+
+
+### `polaris/adme-fang-perm-1`
+
+|    | Test set   | Target label     | Metric              |    Score |
+|---:|:-----------|:-----------------|:--------------------|---------:|
+|  0 | test       | LOG_MDR1-MDCK_ER | mean_squared_error  | 0.241688 |
+|  1 | test       | LOG_MDR1-MDCK_ER | explained_var       | 0.51234  |
+|  2 | test       | LOG_MDR1-MDCK_ER | mean_absolute_error | 0.38705  |
+|  3 | test       | LOG_MDR1-MDCK_ER | r2                  | 0.512129 |
+|  4 | test       | LOG_MDR1-MDCK_ER | pearsonr            | 0.726028 |
+|  5 | test       | LOG_MDR1-MDCK_ER | spearmanr           | 0.717949 |
+
+
+### `polaris/adme-fang-rclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RLM_CLint  | mean_squared_error  | 0.337696 |
+|  1 | test       | LOG_RLM_CLint  | explained_var       | 0.401827 |
+|  2 | test       | LOG_RLM_CLint  | mean_absolute_error | 0.465775 |
+|  3 | test       | LOG_RLM_CLint  | r2                  | 0.401825 |
+|  4 | test       | LOG_RLM_CLint  | pearsonr            | 0.634284 |
+|  5 | test       | LOG_RLM_CLint  | spearmanr           | 0.633687 |
+
+
+### `polaris/adme-fang-hclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HLM_CLint  | mean_squared_error  | 0.232478 |
+|  1 | test       | LOG_HLM_CLint  | explained_var       | 0.401928 |
+|  2 | test       | LOG_HLM_CLint  | mean_absolute_error | 0.386903 |
+|  3 | test       | LOG_HLM_CLint  | r2                  | 0.401462 |
+|  4 | test       | LOG_HLM_CLint  | pearsonr            | 0.635156 |
+|  5 | test       | LOG_HLM_CLint  | spearmanr           | 0.642709 |
+
+
+### `tdcommons/lipophilicity-astrazeneca`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.582145 |
+
+
+### `tdcommons/ppbr-az`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 8.65084 |
+
+
+### `tdcommons/clearance-hepatocyte-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.296368 |
+
+
+### `tdcommons/cyp2d6-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.639051 |
+
+
+### `tdcommons/half-life-obach`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.321151 |
+
+
+### `tdcommons/cyp2c9-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.343236 |
+
+
+### `tdcommons/clearance-microsome-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.513451 |
+
+
+### `tdcommons/dili`
+
+|    | Test set   | Target label   | Metric   |   Score |
+|---:|:-----------|:---------------|:---------|--------:|
+|  0 | test       | Y              | roc_auc  | 0.93913 |
+
+
+### `tdcommons/bioavailability-ma`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.641669 |
+
+
+### `tdcommons/vdss-lombardo`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.485273 |
+
+
+### `tdcommons/cyp3a4-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.648282 |
+
+
+### `tdcommons/pgp-broccatelli`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.892195 |
+
+
+### `tdcommons/caco2-wang`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.313271 |
+
+
+### `tdcommons/herg`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.801178 |
+
+
+### `tdcommons/bbb-martins`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.877482 |
+
+
+### `tdcommons/ames`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.847607 |
+
+
+### `tdcommons/ld50-zhu`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 0.62747 |
+
+
+### Summary
+
+```
+results_dict = {
+    "polaris/pkis2-ret-wt-cls-v2": 0.42453568106157136,
+    "polaris/pkis2-ret-wt-reg-v2": 948.7332679787094,
+    "polaris/pkis2-kit-wt-cls-v2": 0.5283717760092553,
+    "polaris/pkis2-kit-wt-reg-v2": 867.5837621571959,
+    "polaris/pkis2-egfr-wt-reg-v2": 514.9571847016972,
+    "polaris/adme-fang-solu-1": 0.5362095232329354,
+    "polaris/adme-fang-rppb-1": 0.6963829662099205,
+    "polaris/adme-fang-hppb-1": 0.8104548528427337,
+    "polaris/adme-fang-perm-1": 0.7260280586863765,
+    "polaris/adme-fang-rclint-1": 0.6342843257338214,
+    "polaris/adme-fang-hclint-1": 0.6351560373796259,
+    "tdcommons/lipophilicity-astrazeneca": 0.5821450799306234,
+    "tdcommons/ppbr-az": 8.650838637241097,
+    "tdcommons/clearance-hepatocyte-az": 0.2963675047906221,
+    "tdcommons/cyp2d6-substrate-carbonmangels": 0.6390512967621402,
+    "tdcommons/half-life-obach": 0.3211509985562523,
+    "tdcommons/cyp2c9-substrate-carbonmangels": 0.3432361645904026,
+    "tdcommons/clearance-microsome-az": 0.5134507045580553,
+    "tdcommons/dili": 0.9391304347826087,
+    "tdcommons/bioavailability-ma": 0.6416694379780512,
+    "tdcommons/vdss-lombardo": 0.48527336388515635,
+    "tdcommons/cyp3a4-substrate-carbonmangels": 0.6482820976491862,
+    "tdcommons/pgp-broccatelli": 0.8921954145561184,
+    "tdcommons/caco2-wang": 0.3132711822529553,
+    "tdcommons/herg": 0.8011782032400588,
+    "tdcommons/bbb-martins": 0.877482020012508,
+    "tdcommons/ames": 0.8476071589418238,
+    "tdcommons/ld50-zhu": 0.6274696501195027
+}
+```
+## Random Seed 117
+
+### `polaris/pkis2-ret-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_RET        | f1          | 0.272727 |
+|  1 | test       | CLS_RET        | pr_auc      | 0.41899  |
+|  2 | test       | CLS_RET        | cohen_kappa | 0.215541 |
+|  3 | test       | CLS_RET        | mcc         | 0.266557 |
+|  4 | test       | CLS_RET        | roc_auc     | 0.757436 |
+|  5 | test       | CLS_RET        | accuracy    | 0.849057 |
+
+
+### `polaris/pkis2-ret-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | RET            | mean_squared_error  | 989.07     |
+|  1 | test       | RET            | explained_var       |   0.201657 |
+|  2 | test       | RET            | mean_absolute_error |  23.9394   |
+|  3 | test       | RET            | r2                  |   0.167033 |
+|  4 | test       | RET            | pearsonr            |   0.450163 |
+|  5 | test       | RET            | spearmanr           |   0.429934 |
+
+
+### `polaris/pkis2-kit-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_KIT        | f1          | 0.540541 |
+|  1 | test       | CLS_KIT        | pr_auc      | 0.612952 |
+|  2 | test       | CLS_KIT        | cohen_kappa | 0.457048 |
+|  3 | test       | CLS_KIT        | mcc         | 0.468918 |
+|  4 | test       | CLS_KIT        | roc_auc     | 0.779739 |
+|  5 | test       | CLS_KIT        | accuracy    | 0.853448 |
+
+
+### `polaris/pkis2-kit-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | KIT            | mean_squared_error  | 884.464    |
+|  1 | test       | KIT            | explained_var       |   0.274623 |
+|  2 | test       | KIT            | mean_absolute_error |  23.5659   |
+|  3 | test       | KIT            | r2                  |   0.267029 |
+|  4 | test       | KIT            | pearsonr            |   0.527724 |
+|  5 | test       | KIT            | spearmanr           |   0.486078 |
+
+
+### `polaris/pkis2-egfr-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | EGFR           | mean_squared_error  | 525.994    |
+|  1 | test       | EGFR           | explained_var       |   0.348296 |
+|  2 | test       | EGFR           | mean_absolute_error |  17.7983   |
+|  3 | test       | EGFR           | r2                  |   0.347214 |
+|  4 | test       | EGFR           | pearsonr            |   0.591934 |
+|  5 | test       | EGFR           | spearmanr           |   0.344683 |
+
+
+### `polaris/adme-fang-solu-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_SOLUBILITY | mean_squared_error  | 0.391045 |
+|  1 | test       | LOG_SOLUBILITY | explained_var       | 0.279018 |
+|  2 | test       | LOG_SOLUBILITY | mean_absolute_error | 0.439855 |
+|  3 | test       | LOG_SOLUBILITY | r2                  | 0.278752 |
+|  4 | test       | LOG_SOLUBILITY | pearsonr            | 0.529331 |
+|  5 | test       | LOG_SOLUBILITY | spearmanr           | 0.438825 |
+
+
+### `polaris/adme-fang-rppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RPPB       | mean_squared_error  | 0.43617  |
+|  1 | test       | LOG_RPPB       | explained_var       | 0.509087 |
+|  2 | test       | LOG_RPPB       | mean_absolute_error | 0.488844 |
+|  3 | test       | LOG_RPPB       | r2                  | 0.509084 |
+|  4 | test       | LOG_RPPB       | pearsonr            | 0.751125 |
+|  5 | test       | LOG_RPPB       | spearmanr           | 0.848696 |
+
+
+### `polaris/adme-fang-hppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HPPB       | mean_squared_error  | 0.230762 |
+|  1 | test       | LOG_HPPB       | explained_var       | 0.667771 |
+|  2 | test       | LOG_HPPB       | mean_absolute_error | 0.380266 |
+|  3 | test       | LOG_HPPB       | r2                  | 0.618977 |
+|  4 | test       | LOG_HPPB       | pearsonr            | 0.81851  |
+|  5 | test       | LOG_HPPB       | spearmanr           | 0.832302 |
+
+
+### `polaris/adme-fang-perm-1`
+
+|    | Test set   | Target label     | Metric              |    Score |
+|---:|:-----------|:-----------------|:--------------------|---------:|
+|  0 | test       | LOG_MDR1-MDCK_ER | mean_squared_error  | 0.23916  |
+|  1 | test       | LOG_MDR1-MDCK_ER | explained_var       | 0.517612 |
+|  2 | test       | LOG_MDR1-MDCK_ER | mean_absolute_error | 0.382735 |
+|  3 | test       | LOG_MDR1-MDCK_ER | r2                  | 0.517231 |
+|  4 | test       | LOG_MDR1-MDCK_ER | pearsonr            | 0.729735 |
+|  5 | test       | LOG_MDR1-MDCK_ER | spearmanr           | 0.714955 |
+
+
+### `polaris/adme-fang-rclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RLM_CLint  | mean_squared_error  | 0.336471 |
+|  1 | test       | LOG_RLM_CLint  | explained_var       | 0.403995 |
+|  2 | test       | LOG_RLM_CLint  | mean_absolute_error | 0.466746 |
+|  3 | test       | LOG_RLM_CLint  | r2                  | 0.403995 |
+|  4 | test       | LOG_RLM_CLint  | pearsonr            | 0.636161 |
+|  5 | test       | LOG_RLM_CLint  | spearmanr           | 0.638649 |
+
+
+### `polaris/adme-fang-hclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HLM_CLint  | mean_squared_error  | 0.237015 |
+|  1 | test       | LOG_HLM_CLint  | explained_var       | 0.390073 |
+|  2 | test       | LOG_HLM_CLint  | mean_absolute_error | 0.38859  |
+|  3 | test       | LOG_HLM_CLint  | r2                  | 0.389782 |
+|  4 | test       | LOG_HLM_CLint  | pearsonr            | 0.624927 |
+|  5 | test       | LOG_HLM_CLint  | spearmanr           | 0.633656 |
+
+
+### `tdcommons/lipophilicity-astrazeneca`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 0.57911 |
+
+
+### `tdcommons/ppbr-az`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 8.48898 |
+
+
+### `tdcommons/clearance-hepatocyte-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.320316 |
+
+
+### `tdcommons/cyp2d6-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.602959 |
+
+
+### `tdcommons/half-life-obach`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.352554 |
+
+
+### `tdcommons/cyp2c9-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.352327 |
+
+
+### `tdcommons/clearance-microsome-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.531801 |
+
+
+### `tdcommons/dili`
+
+|    | Test set   | Target label   | Metric   |   Score |
+|---:|:-----------|:---------------|:---------|--------:|
+|  0 | test       | Y              | roc_auc  | 0.92413 |
+
+
+### `tdcommons/bioavailability-ma`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.696043 |
+
+
+### `tdcommons/vdss-lombardo`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.471002 |
+
+
+### `tdcommons/cyp3a4-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.676876 |
+
+
+### `tdcommons/pgp-broccatelli`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.898594 |
+
+
+### `tdcommons/caco2-wang`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.327235 |
+
+
+### `tdcommons/herg`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.783358 |
+
+
+### `tdcommons/bbb-martins`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.874961 |
+
+
+### `tdcommons/ames`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.846991 |
+
+
+### `tdcommons/ld50-zhu`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.639518 |
+
+
+### Summary
+
+```
+results_dict = {
+    "polaris/pkis2-ret-wt-cls-v2": 0.41899042410611353,
+    "polaris/pkis2-ret-wt-reg-v2": 989.0696491188388,
+    "polaris/pkis2-kit-wt-cls-v2": 0.6129519899095477,
+    "polaris/pkis2-kit-wt-reg-v2": 884.4644972641013,
+    "polaris/pkis2-egfr-wt-reg-v2": 525.994317536522,
+    "polaris/adme-fang-solu-1": 0.5293307811958299,
+    "polaris/adme-fang-rppb-1": 0.7511245986783879,
+    "polaris/adme-fang-hppb-1": 0.8185101282064952,
+    "polaris/adme-fang-perm-1": 0.7297352986685504,
+    "polaris/adme-fang-rclint-1": 0.6361614386877628,
+    "polaris/adme-fang-hclint-1": 0.6249271871778355,
+    "tdcommons/lipophilicity-astrazeneca": 0.5791096051590783,
+    "tdcommons/ppbr-az": 8.488976169920564,
+    "tdcommons/clearance-hepatocyte-az": 0.3203156218191087,
+    "tdcommons/cyp2d6-substrate-carbonmangels": 0.6029586839510781,
+    "tdcommons/half-life-obach": 0.3525540122109843,
+    "tdcommons/cyp2c9-substrate-carbonmangels": 0.35232675685189485,
+    "tdcommons/clearance-microsome-az": 0.5318006368234307,
+    "tdcommons/dili": 0.9241304347826087,
+    "tdcommons/bioavailability-ma": 0.6960425673428665,
+    "tdcommons/vdss-lombardo": 0.47100158877215087,
+    "tdcommons/cyp3a4-substrate-carbonmangels": 0.6768761301989151,
+    "tdcommons/pgp-broccatelli": 0.8985937083444414,
+    "tdcommons/caco2-wang": 0.32723547235680894,
+    "tdcommons/herg": 0.7833578792341679,
+    "tdcommons/bbb-martins": 0.874960913070669,
+    "tdcommons/ames": 0.8469913254616303,
+    "tdcommons/ld50-zhu": 0.6395177601580692
+}
+```
+## Random Seed 709
+
+### `polaris/pkis2-ret-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_RET        | f1          | 0.347826 |
+|  1 | test       | CLS_RET        | pr_auc      | 0.424255 |
+|  2 | test       | CLS_RET        | cohen_kappa | 0.288272 |
+|  3 | test       | CLS_RET        | mcc         | 0.337956 |
+|  4 | test       | CLS_RET        | roc_auc     | 0.733972 |
+|  5 | test       | CLS_RET        | accuracy    | 0.858491 |
+
+
+### `polaris/pkis2-ret-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | RET            | mean_squared_error  | 991.704    |
+|  1 | test       | RET            | explained_var       |   0.193856 |
+|  2 | test       | RET            | mean_absolute_error |  23.9925   |
+|  3 | test       | RET            | r2                  |   0.164814 |
+|  4 | test       | RET            | pearsonr            |   0.442945 |
+|  5 | test       | RET            | spearmanr           |   0.430997 |
+
+
+### `polaris/pkis2-kit-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_KIT        | f1          | 0.526316 |
+|  1 | test       | CLS_KIT        | pr_auc      | 0.547095 |
+|  2 | test       | CLS_KIT        | cohen_kappa | 0.436285 |
+|  3 | test       | CLS_KIT        | mcc         | 0.444197 |
+|  4 | test       | CLS_KIT        | roc_auc     | 0.783849 |
+|  5 | test       | CLS_KIT        | accuracy    | 0.844828 |
+
+
+### `polaris/pkis2-kit-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | KIT            | mean_squared_error  | 929.914    |
+|  1 | test       | KIT            | explained_var       |   0.234544 |
+|  2 | test       | KIT            | mean_absolute_error |  23.9324   |
+|  3 | test       | KIT            | r2                  |   0.229364 |
+|  4 | test       | KIT            | pearsonr            |   0.496219 |
+|  5 | test       | KIT            | spearmanr           |   0.448536 |
+
+
+### `polaris/pkis2-egfr-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | EGFR           | mean_squared_error  | 516.82     |
+|  1 | test       | EGFR           | explained_var       |   0.35939  |
+|  2 | test       | EGFR           | mean_absolute_error |  17.6787   |
+|  3 | test       | EGFR           | r2                  |   0.3586   |
+|  4 | test       | EGFR           | pearsonr            |   0.601695 |
+|  5 | test       | EGFR           | spearmanr           |   0.333879 |
+
+
+### `polaris/adme-fang-solu-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_SOLUBILITY | mean_squared_error  | 0.381076 |
+|  1 | test       | LOG_SOLUBILITY | explained_var       | 0.297342 |
+|  2 | test       | LOG_SOLUBILITY | mean_absolute_error | 0.435483 |
+|  3 | test       | LOG_SOLUBILITY | r2                  | 0.29714  |
+|  4 | test       | LOG_SOLUBILITY | pearsonr            | 0.547044 |
+|  5 | test       | LOG_SOLUBILITY | spearmanr           | 0.451144 |
+
+
+### `polaris/adme-fang-rppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RPPB       | mean_squared_error  | 0.456019 |
+|  1 | test       | LOG_RPPB       | explained_var       | 0.487747 |
+|  2 | test       | LOG_RPPB       | mean_absolute_error | 0.484973 |
+|  3 | test       | LOG_RPPB       | r2                  | 0.486743 |
+|  4 | test       | LOG_RPPB       | pearsonr            | 0.729274 |
+|  5 | test       | LOG_RPPB       | spearmanr           | 0.813043 |
+
+
+### `polaris/adme-fang-hppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HPPB       | mean_squared_error  | 0.235923 |
+|  1 | test       | LOG_HPPB       | explained_var       | 0.654586 |
+|  2 | test       | LOG_HPPB       | mean_absolute_error | 0.386556 |
+|  3 | test       | LOG_HPPB       | r2                  | 0.610455 |
+|  4 | test       | LOG_HPPB       | pearsonr            | 0.811405 |
+|  5 | test       | LOG_HPPB       | spearmanr           | 0.815952 |
+
+
+### `polaris/adme-fang-perm-1`
+
+|    | Test set   | Target label     | Metric              |    Score |
+|---:|:-----------|:-----------------|:--------------------|---------:|
+|  0 | test       | LOG_MDR1-MDCK_ER | mean_squared_error  | 0.243084 |
+|  1 | test       | LOG_MDR1-MDCK_ER | explained_var       | 0.509489 |
+|  2 | test       | LOG_MDR1-MDCK_ER | mean_absolute_error | 0.385552 |
+|  3 | test       | LOG_MDR1-MDCK_ER | r2                  | 0.50931  |
+|  4 | test       | LOG_MDR1-MDCK_ER | pearsonr            | 0.722658 |
+|  5 | test       | LOG_MDR1-MDCK_ER | spearmanr           | 0.718896 |
+
+
+### `polaris/adme-fang-rclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RLM_CLint  | mean_squared_error  | 0.330979 |
+|  1 | test       | LOG_RLM_CLint  | explained_var       | 0.413744 |
+|  2 | test       | LOG_RLM_CLint  | mean_absolute_error | 0.459623 |
+|  3 | test       | LOG_RLM_CLint  | r2                  | 0.413723 |
+|  4 | test       | LOG_RLM_CLint  | pearsonr            | 0.644205 |
+|  5 | test       | LOG_RLM_CLint  | spearmanr           | 0.645889 |
+
+
+### `polaris/adme-fang-hclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HLM_CLint  | mean_squared_error  | 0.232823 |
+|  1 | test       | LOG_HLM_CLint  | explained_var       | 0.40138  |
+|  2 | test       | LOG_HLM_CLint  | mean_absolute_error | 0.386715 |
+|  3 | test       | LOG_HLM_CLint  | r2                  | 0.400574 |
+|  4 | test       | LOG_HLM_CLint  | pearsonr            | 0.634438 |
+|  5 | test       | LOG_HLM_CLint  | spearmanr           | 0.641295 |
+
+
+### `tdcommons/lipophilicity-astrazeneca`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.583067 |
+
+
+### `tdcommons/ppbr-az`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 8.66189 |
+
+
+### `tdcommons/clearance-hepatocyte-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.314395 |
+
+
+### `tdcommons/cyp2d6-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.633786 |
+
+
+### `tdcommons/half-life-obach`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.439078 |
+
+
+### `tdcommons/cyp2c9-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.343511 |
+
+
+### `tdcommons/clearance-microsome-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.485208 |
+
+
+### `tdcommons/dili`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.929565 |
+
+
+### `tdcommons/bioavailability-ma`
+
+|    | Test set   | Target label   | Metric   |   Score |
+|---:|:-----------|:---------------|:---------|--------:|
+|  0 | test       | Y              | roc_auc  | 0.66129 |
+
+
+### `tdcommons/vdss-lombardo`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.519411 |
+
+
+### `tdcommons/cyp3a4-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.656985 |
+
+
+### `tdcommons/pgp-broccatelli`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.892962 |
+
+
+### `tdcommons/caco2-wang`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.305364 |
+
+
+### `tdcommons/herg`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.817526 |
+
+
+### `tdcommons/bbb-martins`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.873632 |
+
+
+### `tdcommons/ames`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.848916 |
+
+
+### `tdcommons/ld50-zhu`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.635504 |
+
+
+### Summary
+
+```
+results_dict = {
+    "polaris/pkis2-ret-wt-cls-v2": 0.4242545472901411,
+    "polaris/pkis2-ret-wt-reg-v2": 991.7041834116138,
+    "polaris/pkis2-kit-wt-cls-v2": 0.5470945603970429,
+    "polaris/pkis2-kit-wt-reg-v2": 929.9137082877505,
+    "polaris/pkis2-egfr-wt-reg-v2": 516.8197904763579,
+    "polaris/adme-fang-solu-1": 0.5470436836730058,
+    "polaris/adme-fang-rppb-1": 0.7292737223857819,
+    "polaris/adme-fang-hppb-1": 0.8114050999458244,
+    "polaris/adme-fang-perm-1": 0.7226575658732739,
+    "polaris/adme-fang-rclint-1": 0.6442050906675219,
+    "polaris/adme-fang-hclint-1": 0.6344376766236837,
+    "tdcommons/lipophilicity-astrazeneca": 0.5830668231589454,
+    "tdcommons/ppbr-az": 8.661894501223761,
+    "tdcommons/clearance-hepatocyte-az": 0.31439475338345674,
+    "tdcommons/cyp2d6-substrate-carbonmangels": 0.6337860516670732,
+    "tdcommons/half-life-obach": 0.4390775466877196,
+    "tdcommons/cyp2c9-substrate-carbonmangels": 0.34351108659354856,
+    "tdcommons/clearance-microsome-az": 0.485207715931403,
+    "tdcommons/dili": 0.9295652173913043,
+    "tdcommons/bioavailability-ma": 0.661290322580645,
+    "tdcommons/vdss-lombardo": 0.5194109467472516,
+    "tdcommons/cyp3a4-substrate-carbonmangels": 0.656984629294756,
+    "tdcommons/pgp-broccatelli": 0.8929618768328447,
+    "tdcommons/caco2-wang": 0.30536391653066797,
+    "tdcommons/herg": 0.8175257731958763,
+    "tdcommons/bbb-martins": 0.8736319574734208,
+    "tdcommons/ames": 0.8489161722375609,
+    "tdcommons/ld50-zhu": 0.6355040952201142
+}
+```
+## Random Seed 1701
+
+### `polaris/pkis2-ret-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_RET        | f1          | 0.272727 |
+|  1 | test       | CLS_RET        | pr_auc      | 0.435149 |
+|  2 | test       | CLS_RET        | cohen_kappa | 0.215541 |
+|  3 | test       | CLS_RET        | mcc         | 0.266557 |
+|  4 | test       | CLS_RET        | roc_auc     | 0.763054 |
+|  5 | test       | CLS_RET        | accuracy    | 0.849057 |
+
+
+### `polaris/pkis2-ret-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | RET            | mean_squared_error  | 979.739    |
+|  1 | test       | RET            | explained_var       |   0.207521 |
+|  2 | test       | RET            | mean_absolute_error |  23.7473   |
+|  3 | test       | RET            | r2                  |   0.174891 |
+|  4 | test       | RET            | pearsonr            |   0.456182 |
+|  5 | test       | RET            | spearmanr           |   0.458572 |
+
+
+### `polaris/pkis2-kit-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_KIT        | f1          | 0.514286 |
+|  1 | test       | CLS_KIT        | pr_auc      | 0.568372 |
+|  2 | test       | CLS_KIT        | cohen_kappa | 0.434633 |
+|  3 | test       | CLS_KIT        | mcc         | 0.455516 |
+|  4 | test       | CLS_KIT        | roc_auc     | 0.790377 |
+|  5 | test       | CLS_KIT        | accuracy    | 0.853448 |
+
+
+### `polaris/pkis2-kit-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | KIT            | mean_squared_error  | 857.112    |
+|  1 | test       | KIT            | explained_var       |   0.295232 |
+|  2 | test       | KIT            | mean_absolute_error |  23.0956   |
+|  3 | test       | KIT            | r2                  |   0.289696 |
+|  4 | test       | KIT            | pearsonr            |   0.545324 |
+|  5 | test       | KIT            | spearmanr           |   0.508984 |
+
+
+### `polaris/pkis2-egfr-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | EGFR           | mean_squared_error  | 527.29     |
+|  1 | test       | EGFR           | explained_var       |   0.346195 |
+|  2 | test       | EGFR           | mean_absolute_error |  17.9463   |
+|  3 | test       | EGFR           | r2                  |   0.345606 |
+|  4 | test       | EGFR           | pearsonr            |   0.590399 |
+|  5 | test       | EGFR           | spearmanr           |   0.320402 |
+
+
+### `polaris/adme-fang-solu-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_SOLUBILITY | mean_squared_error  | 0.390772 |
+|  1 | test       | LOG_SOLUBILITY | explained_var       | 0.279597 |
+|  2 | test       | LOG_SOLUBILITY | mean_absolute_error | 0.439711 |
+|  3 | test       | LOG_SOLUBILITY | r2                  | 0.279256 |
+|  4 | test       | LOG_SOLUBILITY | pearsonr            | 0.530124 |
+|  5 | test       | LOG_SOLUBILITY | spearmanr           | 0.446993 |
+
+
+### `polaris/adme-fang-rppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RPPB       | mean_squared_error  | 0.463777 |
+|  1 | test       | LOG_RPPB       | explained_var       | 0.478194 |
+|  2 | test       | LOG_RPPB       | mean_absolute_error | 0.481523 |
+|  3 | test       | LOG_RPPB       | r2                  | 0.478012 |
+|  4 | test       | LOG_RPPB       | pearsonr            | 0.74237  |
+|  5 | test       | LOG_RPPB       | spearmanr           | 0.818261 |
+
+
+### `polaris/adme-fang-hppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HPPB       | mean_squared_error  | 0.234384 |
+|  1 | test       | LOG_HPPB       | explained_var       | 0.655962 |
+|  2 | test       | LOG_HPPB       | mean_absolute_error | 0.389905 |
+|  3 | test       | LOG_HPPB       | r2                  | 0.612997 |
+|  4 | test       | LOG_HPPB       | pearsonr            | 0.813314 |
+|  5 | test       | LOG_HPPB       | spearmanr           | 0.815036 |
+
+
+### `polaris/adme-fang-perm-1`
+
+|    | Test set   | Target label     | Metric              |    Score |
+|---:|:-----------|:-----------------|:--------------------|---------:|
+|  0 | test       | LOG_MDR1-MDCK_ER | mean_squared_error  | 0.238962 |
+|  1 | test       | LOG_MDR1-MDCK_ER | explained_var       | 0.517752 |
+|  2 | test       | LOG_MDR1-MDCK_ER | mean_absolute_error | 0.384187 |
+|  3 | test       | LOG_MDR1-MDCK_ER | r2                  | 0.517631 |
+|  4 | test       | LOG_MDR1-MDCK_ER | pearsonr            | 0.730261 |
+|  5 | test       | LOG_MDR1-MDCK_ER | spearmanr           | 0.716793 |
+
+
+### `polaris/adme-fang-rclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RLM_CLint  | mean_squared_error  | 0.337345 |
+|  1 | test       | LOG_RLM_CLint  | explained_var       | 0.402481 |
+|  2 | test       | LOG_RLM_CLint  | mean_absolute_error | 0.464562 |
+|  3 | test       | LOG_RLM_CLint  | r2                  | 0.402447 |
+|  4 | test       | LOG_RLM_CLint  | pearsonr            | 0.634997 |
+|  5 | test       | LOG_RLM_CLint  | spearmanr           | 0.637751 |
+
+
+### `polaris/adme-fang-hclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HLM_CLint  | mean_squared_error  | 0.234796 |
+|  1 | test       | LOG_HLM_CLint  | explained_var       | 0.395908 |
+|  2 | test       | LOG_HLM_CLint  | mean_absolute_error | 0.388353 |
+|  3 | test       | LOG_HLM_CLint  | r2                  | 0.395494 |
+|  4 | test       | LOG_HLM_CLint  | pearsonr            | 0.629836 |
+|  5 | test       | LOG_HLM_CLint  | spearmanr           | 0.63415  |
+
+
+### `tdcommons/lipophilicity-astrazeneca`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.585335 |
+
+
+### `tdcommons/ppbr-az`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 8.64395 |
+
+
+### `tdcommons/clearance-hepatocyte-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.307289 |
+
+
+### `tdcommons/cyp2d6-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.616584 |
+
+
+### `tdcommons/half-life-obach`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.345166 |
+
+
+### `tdcommons/cyp2c9-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.330362 |
+
+
+### `tdcommons/clearance-microsome-az`
+
+|    | Test set   | Target label   | Metric    |   Score |
+|---:|:-----------|:---------------|:----------|--------:|
+|  0 | test       | Y              | spearmanr | 0.50978 |
+
+
+### `tdcommons/dili`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.939783 |
+
+
+### `tdcommons/bioavailability-ma`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.670602 |
+
+
+### `tdcommons/vdss-lombardo`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.481279 |
+
+
+### `tdcommons/cyp3a4-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |   Score |
+|---:|:-----------|:---------------|:---------|--------:|
+|  0 | test       | Y              | roc_auc  | 0.65269 |
+
+
+### `tdcommons/pgp-broccatelli`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.895661 |
+
+
+### `tdcommons/caco2-wang`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.313177 |
+
+
+### `tdcommons/herg`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.790869 |
+
+
+### `tdcommons/bbb-martins`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.876329 |
+
+
+### `tdcommons/ames`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.844284 |
+
+
+### `tdcommons/ld50-zhu`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.632114 |
+
+
+### Summary
+
+```
+results_dict = {
+    "polaris/pkis2-ret-wt-cls-v2": 0.43514913531571775,
+    "polaris/pkis2-ret-wt-reg-v2": 979.7387156693242,
+    "polaris/pkis2-kit-wt-cls-v2": 0.5683717594681063,
+    "polaris/pkis2-kit-wt-reg-v2": 857.1120712468954,
+    "polaris/pkis2-egfr-wt-reg-v2": 527.2898017996328,
+    "polaris/adme-fang-solu-1": 0.5301240232229776,
+    "polaris/adme-fang-rppb-1": 0.7423695082046937,
+    "polaris/adme-fang-hppb-1": 0.8133142078162978,
+    "polaris/adme-fang-perm-1": 0.7302612661195375,
+    "polaris/adme-fang-rclint-1": 0.6349973324108293,
+    "polaris/adme-fang-hclint-1": 0.6298356591737979,
+    "tdcommons/lipophilicity-astrazeneca": 0.5853345172234944,
+    "tdcommons/ppbr-az": 8.64394621792761,
+    "tdcommons/clearance-hepatocyte-az": 0.3072888711232589,
+    "tdcommons/cyp2d6-substrate-carbonmangels": 0.6165837305604205,
+    "tdcommons/half-life-obach": 0.345166072144174,
+    "tdcommons/cyp2c9-substrate-carbonmangels": 0.33036171963693695,
+    "tdcommons/clearance-microsome-az": 0.5097795818862642,
+    "tdcommons/dili": 0.9397826086956522,
+    "tdcommons/bioavailability-ma": 0.6706019288327236,
+    "tdcommons/vdss-lombardo": 0.4812788887642876,
+    "tdcommons/cyp3a4-substrate-carbonmangels": 0.6526898734177217,
+    "tdcommons/pgp-broccatelli": 0.8956611570247935,
+    "tdcommons/caco2-wang": 0.31317674360841197,
+    "tdcommons/herg": 0.7908689248895434,
+    "tdcommons/bbb-martins": 0.8763289555972483,
+    "tdcommons/ames": 0.8442842037243729,
+    "tdcommons/ld50-zhu": 0.6321138691276271
+}
+```
+## Random Seed 9001
+
+### `polaris/pkis2-ret-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_RET        | f1          | 0.363636 |
+|  1 | test       | CLS_RET        | pr_auc      | 0.494992 |
+|  2 | test       | CLS_RET        | cohen_kappa | 0.313599 |
+|  3 | test       | CLS_RET        | mcc         | 0.387824 |
+|  4 | test       | CLS_RET        | roc_auc     | 0.777594 |
+|  5 | test       | CLS_RET        | accuracy    | 0.867925 |
+
+
+### `polaris/pkis2-ret-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | RET            | mean_squared_error  | 985.127    |
+|  1 | test       | RET            | explained_var       |   0.201267 |
+|  2 | test       | RET            | mean_absolute_error |  23.8362   |
+|  3 | test       | RET            | r2                  |   0.170353 |
+|  4 | test       | RET            | pearsonr            |   0.451062 |
+|  5 | test       | RET            | spearmanr           |   0.418432 |
+
+
+### `polaris/pkis2-kit-wt-cls-v2`
+
+|    | Test set   | Target label   | Metric      |    Score |
+|---:|:-----------|:---------------|:------------|---------:|
+|  0 | test       | CLS_KIT        | f1          | 0.5      |
+|  1 | test       | CLS_KIT        | pr_auc      | 0.626527 |
+|  2 | test       | CLS_KIT        | cohen_kappa | 0.413483 |
+|  3 | test       | CLS_KIT        | mcc         | 0.428291 |
+|  4 | test       | CLS_KIT        | roc_auc     | 0.809961 |
+|  5 | test       | CLS_KIT        | accuracy    | 0.844828 |
+
+
+### `polaris/pkis2-kit-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | KIT            | mean_squared_error  | 892.668    |
+|  1 | test       | KIT            | explained_var       |   0.266206 |
+|  2 | test       | KIT            | mean_absolute_error |  23.7006   |
+|  3 | test       | KIT            | r2                  |   0.26023  |
+|  4 | test       | KIT            | pearsonr            |   0.520746 |
+|  5 | test       | KIT            | spearmanr           |   0.474523 |
+
+
+### `polaris/pkis2-egfr-wt-reg-v2`
+
+|    | Test set   | Target label   | Metric              |      Score |
+|---:|:-----------|:---------------|:--------------------|-----------:|
+|  0 | test       | EGFR           | mean_squared_error  | 503.609    |
+|  1 | test       | EGFR           | explained_var       |   0.375132 |
+|  2 | test       | EGFR           | mean_absolute_error |  17.1966   |
+|  3 | test       | EGFR           | r2                  |   0.374995 |
+|  4 | test       | EGFR           | pearsonr            |   0.617468 |
+|  5 | test       | EGFR           | spearmanr           |   0.369952 |
+
+
+### `polaris/adme-fang-solu-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_SOLUBILITY | mean_squared_error  | 0.386554 |
+|  1 | test       | LOG_SOLUBILITY | explained_var       | 0.287179 |
+|  2 | test       | LOG_SOLUBILITY | mean_absolute_error | 0.440776 |
+|  3 | test       | LOG_SOLUBILITY | r2                  | 0.287035 |
+|  4 | test       | LOG_SOLUBILITY | pearsonr            | 0.537356 |
+|  5 | test       | LOG_SOLUBILITY | spearmanr           | 0.450982 |
+
+
+### `polaris/adme-fang-rppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RPPB       | mean_squared_error  | 0.502196 |
+|  1 | test       | LOG_RPPB       | explained_var       | 0.43538  |
+|  2 | test       | LOG_RPPB       | mean_absolute_error | 0.534432 |
+|  3 | test       | LOG_RPPB       | r2                  | 0.43477  |
+|  4 | test       | LOG_RPPB       | pearsonr            | 0.709945 |
+|  5 | test       | LOG_RPPB       | spearmanr           | 0.798261 |
+
+
+### `polaris/adme-fang-hppb-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HPPB       | mean_squared_error  | 0.226304 |
+|  1 | test       | LOG_HPPB       | explained_var       | 0.67331  |
+|  2 | test       | LOG_HPPB       | mean_absolute_error | 0.393825 |
+|  3 | test       | LOG_HPPB       | r2                  | 0.626338 |
+|  4 | test       | LOG_HPPB       | pearsonr            | 0.827073 |
+|  5 | test       | LOG_HPPB       | spearmanr           | 0.833066 |
+
+
+### `polaris/adme-fang-perm-1`
+
+|    | Test set   | Target label     | Metric              |    Score |
+|---:|:-----------|:-----------------|:--------------------|---------:|
+|  0 | test       | LOG_MDR1-MDCK_ER | mean_squared_error  | 0.243081 |
+|  1 | test       | LOG_MDR1-MDCK_ER | explained_var       | 0.509449 |
+|  2 | test       | LOG_MDR1-MDCK_ER | mean_absolute_error | 0.38582  |
+|  3 | test       | LOG_MDR1-MDCK_ER | r2                  | 0.509317 |
+|  4 | test       | LOG_MDR1-MDCK_ER | pearsonr            | 0.722441 |
+|  5 | test       | LOG_MDR1-MDCK_ER | spearmanr           | 0.715976 |
+
+
+### `polaris/adme-fang-rclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_RLM_CLint  | mean_squared_error  | 0.327714 |
+|  1 | test       | LOG_RLM_CLint  | explained_var       | 0.419561 |
+|  2 | test       | LOG_RLM_CLint  | mean_absolute_error | 0.460102 |
+|  3 | test       | LOG_RLM_CLint  | r2                  | 0.419506 |
+|  4 | test       | LOG_RLM_CLint  | pearsonr            | 0.649364 |
+|  5 | test       | LOG_RLM_CLint  | spearmanr           | 0.650511 |
+
+
+### `polaris/adme-fang-hclint-1`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | LOG_HLM_CLint  | mean_squared_error  | 0.231247 |
+|  1 | test       | LOG_HLM_CLint  | explained_var       | 0.40516  |
+|  2 | test       | LOG_HLM_CLint  | mean_absolute_error | 0.384263 |
+|  3 | test       | LOG_HLM_CLint  | r2                  | 0.404633 |
+|  4 | test       | LOG_HLM_CLint  | pearsonr            | 0.637987 |
+|  5 | test       | LOG_HLM_CLint  | spearmanr           | 0.643029 |
+
+
+### `tdcommons/lipophilicity-astrazeneca`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.584748 |
+
+
+### `tdcommons/ppbr-az`
+
+|    | Test set   | Target label   | Metric              |   Score |
+|---:|:-----------|:---------------|:--------------------|--------:|
+|  0 | test       | Y              | mean_absolute_error | 8.69739 |
+
+
+### `tdcommons/clearance-hepatocyte-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.326163 |
+
+
+### `tdcommons/cyp2d6-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.634498 |
+
+
+### `tdcommons/half-life-obach`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.319173 |
+
+
+### `tdcommons/cyp2c9-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | pr_auc   | 0.335627 |
+
+
+### `tdcommons/clearance-microsome-az`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.499395 |
+
+
+### `tdcommons/dili`
+
+|    | Test set   | Target label   | Metric   |   Score |
+|---:|:-----------|:---------------|:---------|--------:|
+|  0 | test       | Y              | roc_auc  | 0.93087 |
+
+
+### `tdcommons/bioavailability-ma`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.658131 |
+
+
+### `tdcommons/vdss-lombardo`
+
+|    | Test set   | Target label   | Metric    |    Score |
+|---:|:-----------|:---------------|:----------|---------:|
+|  0 | test       | Y              | spearmanr | 0.487221 |
+
+
+### `tdcommons/cyp3a4-substrate-carbonmangels`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.665348 |
+
+
+### `tdcommons/pgp-broccatelli`
+
+|    | Test set   | Target label   | Metric   |   Score |
+|---:|:-----------|:---------------|:---------|--------:|
+|  0 | test       | Y              | roc_auc  | 0.88683 |
+
+
+### `tdcommons/caco2-wang`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.322283 |
+
+
+### `tdcommons/herg`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.800736 |
+
+
+### `tdcommons/bbb-martins`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.882837 |
+
+
+### `tdcommons/ames`
+
+|    | Test set   | Target label   | Metric   |    Score |
+|---:|:-----------|:---------------|:---------|---------:|
+|  0 | test       | Y              | roc_auc  | 0.855452 |
+
+
+### `tdcommons/ld50-zhu`
+
+|    | Test set   | Target label   | Metric              |    Score |
+|---:|:-----------|:---------------|:--------------------|---------:|
+|  0 | test       | Y              | mean_absolute_error | 0.635483 |
+
+
+### Summary
+
+```
+results_dict = {
+    "polaris/pkis2-ret-wt-cls-v2": 0.4949917083755303,
+    "polaris/pkis2-ret-wt-reg-v2": 985.1270057767781,
+    "polaris/pkis2-kit-wt-cls-v2": 0.6265268700939152,
+    "polaris/pkis2-kit-wt-reg-v2": 892.6681550668416,
+    "polaris/pkis2-egfr-wt-reg-v2": 503.60920572800364,
+    "polaris/adme-fang-solu-1": 0.5373560942826231,
+    "polaris/adme-fang-rppb-1": 0.7099451993044406,
+    "polaris/adme-fang-hppb-1": 0.8270732870794986,
+    "polaris/adme-fang-perm-1": 0.7224413017476272,
+    "polaris/adme-fang-rclint-1": 0.6493639594515674,
+    "polaris/adme-fang-hclint-1": 0.63798742035071,
+    "tdcommons/lipophilicity-astrazeneca": 0.5847475846835546,
+    "tdcommons/ppbr-az": 8.697385564268384,
+    "tdcommons/clearance-hepatocyte-az": 0.32616297823090545,
+    "tdcommons/cyp2d6-substrate-carbonmangels": 0.6344978484837788,
+    "tdcommons/half-life-obach": 0.31917291357963185,
+    "tdcommons/cyp2c9-substrate-carbonmangels": 0.3356268655279182,
+    "tdcommons/clearance-microsome-az": 0.4993951109302643,
+    "tdcommons/dili": 0.9308695652173913,
+    "tdcommons/bioavailability-ma": 0.6581310276022614,
+    "tdcommons/vdss-lombardo": 0.4872206964987398,
+    "tdcommons/cyp3a4-substrate-carbonmangels": 0.6653481012658228,
+    "tdcommons/pgp-broccatelli": 0.886830178619035,
+    "tdcommons/caco2-wang": 0.32228319391201155,
+    "tdcommons/herg": 0.8007363770250369,
+    "tdcommons/bbb-martins": 0.8828369293308319,
+    "tdcommons/ames": 0.855452427108422,
+    "tdcommons/ld50-zhu": 0.6354834999373543
+}
+```

--- a/models/rf_mordred/evaluate.py
+++ b/models/rf_mordred/evaluate.py
@@ -1,0 +1,222 @@
+from pathlib import Path
+import sys
+import datetime
+import json
+import warnings
+import os
+
+import polaris as po
+from polaris.utils.types import TargetType
+from mordred import Calculator, descriptors
+import numpy as np
+import pandas as pd
+from rdkit.Chem import MolFromSmiles
+from fastprop.data import standard_scale, inverse_standard_scale
+import torch
+
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.metrics import root_mean_squared_error
+
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=FutureWarning)
+
+BENCHMARK_SET = os.getenv('BENCHMARK_SET', "polaris")
+print(f"Running benchmark set {BENCHMARK_SET}")
+
+# Initialize the Mordred calculator once for efficiency
+descriptor_calculator = Calculator(descriptors, ignore_3D=True)
+descriptor_calculator.config(timeout=1)
+
+if __name__ == "__main__":
+    try:
+        output_dir = Path(sys.argv[1])
+    except:
+        print("usage: python evaluate.py OUTPUT_DIR")
+        exit(1)
+    if not output_dir.exists():
+        output_dir.mkdir()
+    output_file = open(output_dir / "train_results.md", "w")
+    output_file.write(
+        f"""# Random Forest Baseline Results
+timestamp: {datetime.datetime.now()}
+"""
+    )
+    performance_dict = {}
+    polaris_benchmarks = (
+        "polaris/pkis2-ret-wt-cls-v2",
+        "polaris/pkis2-ret-wt-reg-v2",
+        "polaris/pkis2-kit-wt-cls-v2",
+        "polaris/pkis2-kit-wt-reg-v2",
+        "polaris/pkis2-egfr-wt-reg-v2",
+        "polaris/adme-fang-solu-1",
+        "polaris/adme-fang-rppb-1",
+        "polaris/adme-fang-hppb-1",
+        "polaris/adme-fang-perm-1",
+        "polaris/adme-fang-rclint-1",
+        "polaris/adme-fang-hclint-1",
+        "tdcommons/lipophilicity-astrazeneca",
+        "tdcommons/ppbr-az",
+        "tdcommons/clearance-hepatocyte-az",
+        "tdcommons/cyp2d6-substrate-carbonmangels",
+        "tdcommons/half-life-obach",
+        "tdcommons/cyp2c9-substrate-carbonmangels",
+        "tdcommons/clearance-microsome-az",
+        "tdcommons/dili",
+        "tdcommons/bioavailability-ma",
+        "tdcommons/vdss-lombardo",
+        "tdcommons/cyp3a4-substrate-carbonmangels",
+        "tdcommons/pgp-broccatelli",
+        "tdcommons/caco2-wang",
+        "tdcommons/herg",
+        "tdcommons/bbb-martins",
+        "tdcommons/ames",
+        "tdcommons/ld50-zhu",
+    )
+    moleculeace_benchmarks = (
+        "CHEMBL1862_Ki",
+        "CHEMBL1871_Ki",
+        "CHEMBL2034_Ki",
+        "CHEMBL2047_EC50",
+        "CHEMBL204_Ki",
+        "CHEMBL2147_Ki",
+        "CHEMBL214_Ki",
+        "CHEMBL218_EC50",
+        "CHEMBL219_Ki",
+        "CHEMBL228_Ki",
+        "CHEMBL231_Ki",
+        "CHEMBL233_Ki",
+        "CHEMBL234_Ki",
+        "CHEMBL235_EC50",
+        "CHEMBL236_Ki",
+        "CHEMBL237_EC50",
+        "CHEMBL237_Ki",
+        "CHEMBL238_Ki",
+        "CHEMBL239_EC50",
+        "CHEMBL244_Ki",
+        "CHEMBL262_Ki",
+        "CHEMBL264_Ki",
+        "CHEMBL2835_Ki",
+        "CHEMBL287_Ki",
+        "CHEMBL2971_Ki",
+        "CHEMBL3979_EC50",
+        "CHEMBL4005_Ki",
+        "CHEMBL4203_Ki",
+        "CHEMBL4616_EC50",
+        "CHEMBL4792_Ki",
+    )
+
+    for random_seed in (42, 117, 709, 1701, 9001):
+        output_file.write(f"## Random Seed {random_seed}\n")
+        seed_dir = output_dir / f"seed_{random_seed}"
+        if not seed_dir.exists():
+            seed_dir.mkdir()
+        
+        for benchmark_name in (polaris_benchmarks if BENCHMARK_SET == "polaris" else moleculeace_benchmarks):
+            if BENCHMARK_SET == "polaris":
+                # load the benchmarking data
+                benchmark = po.load_benchmark(benchmark_name)
+                smiles_col = list(benchmark.input_cols)[0]
+                target_cols = list(benchmark.target_cols)
+                train, test = benchmark.get_train_test_split()
+                train_df, test_df = train.as_dataframe(), test.as_dataframe()
+
+                # extract metadata, targets, and inputs
+                task_type = benchmark.target_types[target_cols[0]]
+                targets = train_df[target_cols]
+                targets = targets.fillna(targets.mean(axis=0)).to_numpy().ravel()
+                train_smiles = train_df[smiles_col]
+                test_smiles = test_df[smiles_col]
+            else:
+                df = pd.read_csv(f"https://raw.githubusercontent.com/molML/MoleculeACE/7e6de0bd2968c56589c580f2a397f01c531ede26/MoleculeACE/Data/benchmark_data/{benchmark_name}.csv")
+                train_df, test_df = df[df["split"] == "train"], df[df["split"] == "test"]
+
+                # extract metadata, targets, and inputs
+                task_type = TargetType.REGRESSION
+                targets = train_df["y"].to_numpy().ravel()
+                train_smiles = train_df["smiles"]
+                test_smiles = test_df["smiles"]
+
+            # Convert molecules to descriptors first, matching how the MLP script processes data
+            train_mols = list(map(MolFromSmiles, train_smiles))
+            test_mols = list(map(MolFromSmiles, test_smiles))
+            
+            # Set molecule names to empty strings as in the MLP script
+            for mol in train_mols:
+                mol.SetProp("_Name", "")
+            for mol in test_mols:
+                mol.SetProp("_Name", "")
+            
+            # Calculate descriptors using the global calculator
+            train_desc = descriptor_calculator.pandas(train_mols).fill_missing().to_numpy(dtype=np.float32)
+            test_desc = descriptor_calculator.pandas(test_mols).fill_missing().to_numpy(dtype=np.float32)
+            
+            # Convert to torch tensors for use with standard_scale
+            train_desc_tensor = torch.tensor(train_desc, dtype=torch.float32)
+            targets_tensor = torch.tensor(targets, dtype=torch.float32).reshape(-1, 1)
+            
+            # Scale features and targets as in the MLP script
+            if task_type == TargetType.REGRESSION:
+                _, target_means, target_vars = standard_scale(targets_tensor)
+                targets_scaled = standard_scale(targets_tensor, target_means, target_vars).numpy().ravel()
+                targets = targets_scaled
+                
+            # Feature scaling - exactly as in the MLP script with clamping as in RescalingEncoder
+            _, feature_means, feature_vars = standard_scale(train_desc_tensor)
+            train_desc = standard_scale(train_desc_tensor, feature_means, feature_vars).clamp(min=-6, max=6).numpy()
+            test_desc_tensor = torch.tensor(test_desc, dtype=torch.float32)
+            test_desc = standard_scale(test_desc_tensor, feature_means, feature_vars).clamp(min=-6, max=6).numpy()
+            
+            # Create and train model
+            if task_type == TargetType.REGRESSION:
+                model = RandomForestRegressor(random_state=random_seed)
+            else:
+                model = RandomForestClassifier(random_state=random_seed)
+            
+            # Train model directly on the descriptors
+            model.fit(train_desc, targets)
+
+            # generate predictions and evaluate performance
+            print(f"Evaluating benchmark: {benchmark_name}")
+            
+            if task_type == TargetType.CLASSIFICATION:
+                # Get probability predictions for classification tasks
+                predictions = model.predict_proba(test_desc)[:, 1].flatten()
+                results = benchmark.evaluate(predictions > 0.5, predictions).results
+                performance = results.query(f"Metric == '{benchmark.main_metric.label}'")['Score'].values[0]
+            elif task_type == TargetType.REGRESSION:
+                # Get value predictions for regression tasks
+                predictions = model.predict(test_desc).flatten()
+                # Inverse transform the predictions using the same scaling approach as in the MLP script
+                predictions_tensor = torch.tensor(predictions, dtype=torch.float32).reshape(-1, 1)
+                predictions = inverse_standard_scale(predictions_tensor, target_means, target_vars).numpy().ravel()
+                
+                if BENCHMARK_SET == "polaris":
+                    results = benchmark.evaluate(predictions).results
+                    performance = results.query(f"Metric == '{benchmark.main_metric.label}'")['Score'].values[0]
+                else:
+                    # MoleculeACE evaluation metrics
+                    results = pd.DataFrame.from_records([
+                        dict(metric="overall test rmse", value=root_mean_squared_error(predictions, test_df["y"])),
+                        dict(metric="noncliff test rmse", value=root_mean_squared_error(predictions[test_df["cliff_mol"] == 0], test_df[test_df["cliff_mol"] == 0]["y"])),
+                        dict(metric="cliff test rmse", value=root_mean_squared_error(predictions[test_df["cliff_mol"] == 1], test_df[test_df["cliff_mol"] == 1]["y"])),
+                    ], index="metric")
+                    performance = {"cliff": results.at["cliff test rmse", "value"], "noncliff": results.at["noncliff test rmse", "value"]}
+            
+            output_file.write(f"""
+### `{benchmark_name}`
+
+{results.to_markdown()}
+
+""")
+            performance_dict[benchmark_name] = performance
+
+        output_file.write(
+            f"""
+### Summary
+
+```
+results_dict = {json.dumps(performance_dict, indent=4)}
+```
+"""
+        )


### PR DESCRIPTION
Starting this PR to add the baseline Random Forest model trained on Mordred descriptors. I think this would be useful to benchmark against among the 'many ways to use the descriptors'. Also a point raised by someone on LinkedIn and validated by some of our colleagues.


The first commit in this PR is dedicated to the RF_Mordred model. The implementation/training is in evaluat.py file with the results appended as the .md file.

TODO:
In the next commit, I will edit the PCA code to exactly match the descriptor_mlp and make it useful for both Polaris and MoleculeACE (currently, it is only used for Polaris).
